### PR TITLE
refactor: update schema generation functions to use snake_case conversion

### DIFF
--- a/auth/go.mod
+++ b/auth/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/adjust/gorails v0.0.0-20171013043634-2786ed0c03d3
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
-	github.com/dosco/graphjin/core/v3 v
+	github.com/dosco/graphjin/core/v3 v3.0.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gomodule/redigo v1.9.2
 	github.com/gorilla/websocket v1.5.3
@@ -14,6 +14,8 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.27.0
 )
+
+replace github.com/dosco/graphjin/core/v3 => ../core
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -7,8 +7,10 @@ toolchain go1.23.1
 require (
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/dop251/goja v0.0.0-20240828124009-016eb7256539
-	github.com/dosco/graphjin/core/v3 v
-	github.com/dosco/graphjin/serv/v3 v
+	github.com/dosco/graphjin/core/v3 v3.0.0
+	github.com/dosco/graphjin/serv/v3 v3.0.0
+	github.com/dosco/graphjin/auth/v3 v3.0.0
+	github.com/dosco/graphjin/plugin/otel/v3 v3.0.0
 	github.com/gosimple/slug v1.14.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jvatic/goja-babel v0.0.0-20240829121804-52a2d5a94eb5
@@ -17,6 +19,11 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/text v0.18.0
 )
+
+replace github.com/dosco/graphjin/core/v3 => ../core
+replace github.com/dosco/graphjin/serv/v3 => ../serv
+replace github.com/dosco/graphjin/auth/v3 => ../auth
+replace github.com/dosco/graphjin/plugin/otel/v3 => ../plugin/otel
 
 require (
 	cloud.google.com/go/auth v0.4.1 // indirect
@@ -45,8 +52,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
-	github.com/dosco/graphjin/auth/v3 v // indirect
-	github.com/dosco/graphjin/plugin/otel/v3 v // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -144,3 +149,4 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+

--- a/conf/go.mod
+++ b/conf/go.mod
@@ -1,11 +1,13 @@
-module github.com/dosco/graphjin/conf/v3
+module github.com/aegion-dynamic/graphjin/conf/v3
 
 go 1.18
 
 require (
-	github.com/dosco/graphjin/core/v3 v
+	github.com/aegion-dynamic/graphjin/core/v3 v3.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/aegion-dynamic/graphjin/core/v3 => ../core
 
 require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/core/internal/qcode/schema.go
+++ b/core/internal/qcode/schema.go
@@ -84,7 +84,7 @@ func parseTFieldsColumns(tableSchema, tableName string, fields []graph.TField) (
 		isRecursive := (dir.RelatedSchema == tableSchema &&
 			dir.RelatedType == tableName)
 
-		colType := pascalToSnakeSpace(f.Type)
+		colType := typeToDB(f.Type)
 		if dir.TypeSuffix != "" {
 			colType += "(" + dir.TypeSuffix + ")"
 		}
@@ -123,7 +123,7 @@ func parseTFieldsFunction(fn *sdata.DBFunction, fields []graph.TField) (
 		p := sdata.DBFuncParam{
 			ID:   i,
 			Name: f.Name,
-			Type: pascalToSnakeSpace(f.Type),
+			Type: typeToDB(f.Type),
 		}
 		switch {
 		case dir.Input:
@@ -264,4 +264,11 @@ func pascalToSnakeSpace(s string) string {
 		result += strings.ToLower(string(r))
 	}
 	return result
+}
+
+// typeToDB normalizes a GraphQL type name to the DB form (snake_case).
+// Preserves verbatim snake_case (e.g. order_status) and converts PascalCase
+// or space-separated names to snake_case so enum types round-trip correctly.
+func typeToDB(s string) string {
+	return strings.ReplaceAll(pascalToSnakeSpace(s), " ", "_")
 }

--- a/core/internal/qcode/schema.go
+++ b/core/internal/qcode/schema.go
@@ -266,9 +266,23 @@ func pascalToSnakeSpace(s string) string {
 	return result
 }
 
-// typeToDB normalizes a GraphQL type name to the DB form (snake_case).
-// Preserves verbatim snake_case (e.g. order_status) and converts PascalCase
-// or space-separated names to snake_case so enum types round-trip correctly.
+// dbTypesWithSpaces lists known built-in DB types that use spaces in their
+// canonical form (important for round-tripping schema dumps).
+var dbTypesWithSpaces = map[string]struct{}{
+	"character varying":           {},
+	"timestamp without time zone": {},
+	"timestamp with time zone":    {},
+	"double precision":            {},
+}
+
+// typeToDB normalizes a GraphQL type name to the DB form.
+// For enum and custom types it returns snake_case (order_status), while for
+// known built-in types with spaces it preserves the space-separated form
+// (e.g. "CharacterVarying" -> "character varying").
 func typeToDB(s string) string {
-	return strings.ReplaceAll(pascalToSnakeSpace(s), " ", "_")
+	base := pascalToSnakeSpace(s)
+	if _, ok := dbTypesWithSpaces[base]; ok {
+		return base
+	}
+	return strings.ReplaceAll(base, " ", "_")
 }

--- a/core/internal/qcode/schema.go
+++ b/core/internal/qcode/schema.go
@@ -267,12 +267,16 @@ func pascalToSnakeSpace(s string) string {
 }
 
 // dbTypesWithSpaces lists known built-in DB types that use spaces in their
-// canonical form (important for round-tripping schema dumps).
+// canonical form (important for round-tripping schema dumps). Any type listed
+// here will be preserved as-is instead of being converted to snake_case.
 var dbTypesWithSpaces = map[string]struct{}{
 	"character varying":           {},
 	"timestamp without time zone": {},
 	"timestamp with time zone":    {},
+	"time without time zone":      {},
+	"time with time zone":         {},
 	"double precision":            {},
+	"bit varying":                 {},
 }
 
 // typeToDB normalizes a GraphQL type name to the DB form.

--- a/core/schema.go
+++ b/core/schema.go
@@ -105,14 +105,22 @@ func writeSchema(s *sdata.DBInfo, out io.Writer) (err error) {
 	return
 }
 
-// snakeToPascal converts snake_case to PascalCase (e.g. order_status -> OrderStatus).
-// Types without underscores get only the first letter capitalized (e.g. integer -> Integer).
-// Ensures enum and custom type names round-trip correctly when the dump is read with typeToDB.
+// snakeToPascal converts snake_case or space-separated db type names to
+// PascalCase GraphQL type names.
+// Examples:
+//   "order_status"              -> "OrderStatus"
+//   "character varying"         -> "CharacterVarying"
+//   "timestamp without time zone" -> "TimestampWithoutTimeZone"
+// Types without separators get only the first letter capitalized
+// (e.g. "integer" -> "Integer").
 func snakeToPascal(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
+	// Treat spaces and underscores as equivalent separators so multi-word
+	// db types (with spaces) become valid GraphQL type names.
+	s = strings.ReplaceAll(s, " ", "_")
 	parts := strings.Split(s, "_")
 	var out strings.Builder
 	for _, p := range parts {
@@ -120,10 +128,11 @@ func snakeToPascal(s string) string {
 			continue
 		}
 		r := []rune(p)
-		if len(r) > 0 {
-			out.WriteRune(unicode.ToUpper(r[0]))
-			out.WriteString(strings.ToLower(string(r[1:])))
+		if len(r) == 0 {
+			continue
 		}
+		out.WriteRune(unicode.ToUpper(r[0]))
+		out.WriteString(strings.ToLower(string(r[1:])))
 	}
 	return out.String()
 }

--- a/core/schema.go
+++ b/core/schema.go
@@ -33,7 +33,7 @@ const schemaTemplate = `
 
 {{- define "column_type"}}
 {{- $var := .Type|dbtype }}
-{{- $type := (index $var 0)|pascal }}
+{{- $type := (index $var 0)|snakeToPascal }}
 {{- if .Array}}[{{ $type }}]{{else}}{{ $type }}{{end}}
 {{- if .NotNull}}!{{end}}
 {{- "\t" }}
@@ -57,7 +57,7 @@ const schemaTemplate = `
 {{- .Name }}:
 {{- "\t"}}
 {{- $var := .Type|dbtype }}
-{{- (index $var 0)|pascal }}
+{{- (index $var 0)|snakeToPascal }}
 {{- if .Array}}[]{{end}}
 {{- "\t"}}
 {{- if ne (index $var 1) ""}} @type_args({{ (index $var 1) }}){{end}}
@@ -85,8 +85,8 @@ type {{.Name}}
 // writeSchema writes the schema to the given writer
 func writeSchema(s *sdata.DBInfo, out io.Writer) (err error) {
 	fn := template.FuncMap{
-		"pascal": toPascalCase,
-		"dbtype": parseDBType,
+		"dbtype":        parseDBType,
+		"snakeToPascal": snakeToPascal,
 	}
 
 	tmpl, err := template.
@@ -105,25 +105,43 @@ func writeSchema(s *sdata.DBInfo, out io.Writer) (err error) {
 	return
 }
 
-// toPascalCase converts a string to pascal case
-func toPascalCase(text string) string {
-	var sb strings.Builder
-	for _, v := range strings.Fields(text) {
-		sb.WriteRune(unicode.ToUpper(rune(v[0])))
-		sb.WriteString(v[1:])
+// snakeToPascal converts snake_case to PascalCase (e.g. order_status -> OrderStatus).
+// Types without underscores get only the first letter capitalized (e.g. integer -> Integer).
+// Ensures enum and custom type names round-trip correctly when the dump is read with typeToDB.
+func snakeToPascal(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
 	}
-	return sb.String()
+	parts := strings.Split(s, "_")
+	var out strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		r := []rune(p)
+		if len(r) > 0 {
+			out.WriteRune(unicode.ToUpper(r[0]))
+			out.WriteString(strings.ToLower(string(r[1:])))
+		}
+	}
+	return out.String()
 }
 
-var dbTypeRe = regexp.MustCompile(`([a-zA-Z ]+)(\((.+)\))?`)
+// dbTypeRe captures base type (letters, digits, underscores, spaces) and optional args in parens.
+// Including underscore preserves enum and custom type names (e.g. order_status) for snakeToPascal.
+var dbTypeRe = regexp.MustCompile(`([a-zA-Z0-9_ ]+)(\((.+)\))?`)
 
-// parseDBType parses the db type string
+// parseDBType parses the db type string into [baseType, typeArgs].
+// Base type is preserved in full so enum types like "order_status" round-trip correctly.
 func parseDBType(name string) (res [2]string, err error) {
 	v := dbTypeRe.FindStringSubmatch(name)
-	if len(v) == 4 {
-		res = [2]string{v[1], v[3]}
-	} else {
-		err = fmt.Errorf("invalid db type: %s", name)
+	if len(v) >= 2 {
+		res[0] = strings.TrimSpace(v[1])
+		if len(v) == 4 && v[3] != "" {
+			res[1] = v[3]
+		}
+		return res, nil
 	}
-	return
+	return res, fmt.Errorf("invalid db type: %s", name)
 }

--- a/go.work
+++ b/go.work
@@ -12,3 +12,8 @@ use (
 	./tests
 	./wasm
 )
+
+// Ensure all workspace modules use the local ./core for
+// github.com/aegion-dynamic/graphjin/core/v3 to avoid
+// conflicting replacements from individual go.mod files.
+replace github.com/aegion-dynamic/graphjin/core/v3 => ./core

--- a/plugin/otel/go.mod
+++ b/plugin/otel/go.mod
@@ -5,11 +5,13 @@ go 1.21
 toolchain go1.23.1
 
 require (
-	github.com/dosco/graphjin/core/v3 v
+	github.com/aegion-dynamic/graphjin/core/v3 v3.0.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/trace v1.29.0
 )
+
+replace github.com/aegion-dynamic/graphjin/core/v3 => ../core
 
 require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/serv/go.mod
+++ b/serv/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
-	github.com/dosco/graphjin/auth/v3 v
-	github.com/dosco/graphjin/core/v3 v
-	github.com/dosco/graphjin/plugin/otel/v3 v
+	github.com/dosco/graphjin/auth/v3 v3.0.0
+	github.com/dosco/graphjin/core/v3 v3.0.0
+	github.com/dosco/graphjin/plugin/otel/v3 v3.0.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-pkgz/expirable-cache v1.0.0
@@ -31,6 +31,10 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.11.0
 )
+
+replace github.com/dosco/graphjin/auth/v3 => ../auth
+replace github.com/dosco/graphjin/core/v3 => ../core
+replace github.com/dosco/graphjin/plugin/otel/v3 => ../plugin/otel
 
 require (
 	cloud.google.com/go/auth v0.4.1 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,12 +5,15 @@ go 1.21
 toolchain go1.23.1
 
 require (
-	github.com/dosco/graphjin/conf/v3 v
-	github.com/dosco/graphjin/core/v3 v
+	github.com/aegion-dynamic/graphjin/conf/v3 v3.0.0
+	github.com/aegion-dynamic/graphjin/core/v3 v3.0.0
 	github.com/orlangure/gnomock v0.30.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.8.0
 )
+
+replace github.com/aegion-dynamic/graphjin/conf/v3 => ../conf
+replace github.com/aegion-dynamic/graphjin/core/v3 => ../core
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect

--- a/wasm/go.mod
+++ b/wasm/go.mod
@@ -1,11 +1,13 @@
-module github.com/dosco/graphjin/wasm/v3
+module github.com/aegion-dynamic/graphjin/wasm/v3
 
 go 1.18
 
 require (
-	github.com/dosco/graphjin/conf/v3 v
-	github.com/dosco/graphjin/core/v3 v
+	github.com/aegion-dynamic/graphjin/conf/v3 v3.0.0
+	github.com/aegion-dynamic/graphjin/core/v3 v3.0.0
 )
+replace github.com/aegion-dynamic/graphjin/conf/v3 => ../conf
+replace github.com/aegion-dynamic/graphjin/core/v3 => ../core
 
 require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect


### PR DESCRIPTION
- Replaced pascal case conversion with snake_case in schema template for column types.
- Introduced snakeToPascal function to handle conversion from snake_case to PascalCase.
- Updated parseDBType to ensure proper handling of enum types with underscores.
- Refactored type handling in qcode schema to normalize GraphQL types to snake_case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema parse/dump type normalization changes can alter generated GraphQL schemas and DB type round-tripping (enums/custom types and multi-word DB types), which may affect downstream migrations or clients; go module path/replace updates also risk build or dependency resolution issues across the workspace.
> 
> **Overview**
> Schema parsing and schema dumping now **round-trip DB/GraphQL types more predictably** by switching from a simple Pascal→space conversion to explicit normalization: GraphQL type names are converted to DB types via `typeToDB` (snake_case for enums/custom types, preserved spaces for known multi-word built-ins), and dumped DB types are converted back via `snakeToPascal`.
> 
> `parseDBType` and the schema template were updated to preserve underscores/spaces in base types (so enum names like `order_status` and types like `character varying` survive), and workspace/module wiring was adjusted by pinning internal module versions to `v3.0.0`, adding local `replace` directives, and renaming `conf`/`wasm` module paths to `github.com/aegion-dynamic/...` with a `go.work`-level `replace` to keep `core` consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21f949b4d4480d9e4e9eae2db2f32c0c795ddb47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->