### PR TITLE
fix all compilation errors and refactor List logic across core, serv, allow, test

### DIFF
--- a/core/internal/allow/allow.go
+++ b/core/internal/allow/allow.go
@@ -17,6 +17,7 @@ type FS interface {
 	Get(path string) (data []byte, err error)
 	Put(path string, data []byte) (err error)
 	Exists(path string) (exists bool, err error)
+	List(path string) (entries []string, err error)
 }
 
 var ErrUnknownGraphQLQuery = errors.New("unknown graphql query")

--- a/core/internal/graph/parse.go
+++ b/core/internal/graph/parse.go
@@ -75,8 +75,10 @@ type Field struct {
 }
 
 type VarDef struct {
-	Name string
-	Val  *Node
+	Name     string
+	Val      *Node
+	Type     string
+	Required bool
 }
 
 type Arg struct {

--- a/core/openapi.go
+++ b/core/openapi.go
@@ -33,13 +33,13 @@ type OpenAPIServer struct {
 }
 
 type PathItem struct {
-	Get    *Operation `json:"get,omitempty"`
-	Post   *Operation `json:"post,omitempty"`
-	Put    *Operation `json:"put,omitempty"`
-	Delete *Operation `json:"delete,omitempty"`
+	Get    *OpenAPIOperation `json:"get,omitempty"`
+	Post   *OpenAPIOperation `json:"post,omitempty"`
+	Put    *OpenAPIOperation `json:"put,omitempty"`
+	Delete *OpenAPIOperation `json:"delete,omitempty"`
 }
 
-type Operation struct {
+type OpenAPIOperation struct {
 	Summary     string              `json:"summary,omitempty"`
 	Description string              `json:"description,omitempty"`
 	OperationID string              `json:"operationId,omitempty"`
@@ -253,7 +253,7 @@ func (g *GraphJin) extractParameters(varDefs []graph.VarDef) []Parameter {
 			Name:        varDef.Name,
 			In:          "query",
 			Description: fmt.Sprintf("GraphQL variable: %s", varDef.Name),
-			Required:    varDef.Required,
+			Required:    varDef.Required || varDef.Val == nil,
 			Schema:      g.graphQLTypeToOpenAPISchema(varDef.Type),
 		}
 		params = append(params, param)
@@ -550,7 +550,7 @@ func (g *GraphJin) generatePathItem(analysis *QueryAnalysis, components *OpenAPI
 	pathItem := PathItem{}
 
 	for _, method := range analysis.HTTPMethods {
-		operation := &Operation{
+		operation := &OpenAPIOperation{
 			Summary:     fmt.Sprintf("Execute %s query", analysis.Item.Name),
 			Description: fmt.Sprintf("Executes the %s GraphQL query via REST", analysis.Item.Name),
 			OperationID: fmt.Sprintf("%s_%s", strings.ToLower(method), analysis.Item.Name),

--- a/core/osfs.go
+++ b/core/osfs.go
@@ -7,6 +7,23 @@ import (
 	"path/filepath"
 )
 
+// namedFileEntry is satisfied by both os.DirEntry and os.FileInfo.
+type namedFileEntry interface {
+	Name() string
+	IsDir() bool
+}
+
+// filterFileNames extracts file names from a list of entries, skipping subdirectories.
+func FilterFileNames[T namedFileEntry](entries []T) []string {
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names
+}
+
 type osFS struct {
 	basePath string
 }
@@ -55,17 +72,11 @@ func (f *osFS) exists(path string) (ok bool, err error) {
 }
 
 // List returns all files in the directory
-func (f *osFS) List(path string) (entries []string, err error) {
+func (f *osFS) List(path string) ([]string, error) {
 	fullPath := filepath.Join(f.basePath, path)
 	dirEntries, err := os.ReadDir(fullPath)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, entry := range dirEntries {
-		if !entry.IsDir() {
-			entries = append(entries, entry.Name())
-		}
-	}
-	return entries, nil
+	return FilterFileNames(dirEntries), nil
 }

--- a/serv/afero.go
+++ b/serv/afero.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/afero"
+
+	"github.com/dosco/graphjin/core/v3"
 )
 
 type aferoFS struct {
@@ -41,15 +43,10 @@ func (f *aferoFS) Exists(path string) (exists bool, err error) {
 }
 
 // List returns all files in the directory
-func (f *aferoFS) List(path string) (entries []string, err error) {
+func (f *aferoFS) List(path string) ([]string, error) {
 	dirEntries, err := afero.ReadDir(f.fs, path)
 	if err != nil {
 		return nil, err
 	}
-	for _, entry := range dirEntries {
-		if !entry.IsDir() {
-			entries = append(entries, entry.Name())
-		}
-	}
-	return entries, nil
+	return core.FilterFileNames(dirEntries), nil
 }

--- a/serv/afero.go
+++ b/serv/afero.go
@@ -39,3 +39,17 @@ func (f *aferoFS) Put(path string, data []byte) (err error) {
 func (f *aferoFS) Exists(path string) (exists bool, err error) {
 	return afero.Exists(f.fs, path)
 }
+
+// List returns all files in the directory
+func (f *aferoFS) List(path string) (entries []string, err error) {
+	dirEntries, err := afero.ReadDir(f.fs, path)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range dirEntries {
+		if !entry.IsDir() {
+			entries = append(entries, entry.Name())
+		}
+	}
+	return entries, nil
+}

--- a/serv/http.go
+++ b/serv/http.go
@@ -451,7 +451,7 @@ func newDTrace(dtrace propagation.TextMapPropagator, r *http.Request) (context.C
 // openAPIHandler generates and serves the OpenAPI specification
 func (s1 *HttpService) openAPIHandler(ns *string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+		_ = r.Context()
 		s := s1.Load().(*graphjinService)
 
 		// Set content type for JSON

--- a/test_openapi.go
+++ b/test_openapi.go
@@ -90,15 +90,12 @@ func main() {
 
 	// Create a minimal GraphJin configuration
 	config := &core.Config{
-		DB: core.DBConfig{
-			Type: "postgres",                     // This would normally be an actual database
-			DSN:  "postgres://localhost/test_db", // Mock DSN
-		},
+		DBType: "postgres",
 		Debug: true,
 	}
 
 	// Initialize GraphJin (this will fail without a real database, but we can still test the basic structure)
-	gj, err := core.NewGraphJin(config, tempDir)
+	gj, err := core.NewGraphJin(config, nil)
 	if err != nil {
 		log.Printf("Expected error initializing GraphJin (no database): %v", err)
 		log.Println("Continuing with basic structural testing...")


### PR DESCRIPTION
## Fixes compilation errors in aegion-dynamic/graphjin

### Changes:
1. **core/internal/graph/parse.go** - Added `Type` and `Required` fields to `VarDef` struct (needed by openapi.go)
2. **core/openapi.go** - Renamed `Operation` struct to `OpenAPIOperation` to avoid collision with `func Operation()` in api.go. Fixed `extractParameters` to derive `Required` from `varDef.Val == nil`
3. **core/internal/allow/allow.go** - Added `List` method to the FS interface so `ListAll()` compiles
4. **core/osfs.go + serv/afero.go** - Extracted common `FilterFileNames` helper so both `osFS.List` and `aferoFS.List` share the same file-filtering logic instead of duplicating it
5. **serv/http.go** - Fixed unused `ctx` variable
6. **test_openapi.go** - Updated to use current `core.Config` API
